### PR TITLE
feat: JSON配列から複数レコードの一括インポート

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,29 +1,35 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import JsonUploader from '@/components/JsonUploader';
-import FieldPreview from '@/components/FieldPreview';
+import JsonUploader, { ParsedFile } from '@/components/JsonUploader';
+import FieldPreview, { ImportProgress } from '@/components/FieldPreview';
 import { parseLarkBaseUrl, LarkBaseUrlInfo } from '@/lib/lark';
 
 type Step = 'upload' | 'preview' | 'success';
 
-interface ImportResult {
-  tableId: string;
-  recordId: string;
-  fieldsCount: number;
+interface ImportSummary {
+  totalRecords: number;
+  successCount: number;
+  failedCount: number;
   createdFieldsCount: number;
 }
 
 export default function Home() {
   const [step, setStep] = useState<Step>('upload');
-  const [jsonData, setJsonData] = useState<Record<string, unknown> | null>(null);
-  const [sourceName, setSourceName] = useState('');
+  const [parsedFiles, setParsedFiles] = useState<ParsedFile[]>([]);
   const [larkUrl, setLarkUrl] = useState('');
   const [urlInfo, setUrlInfo] = useState<LarkBaseUrlInfo | null>(null);
   const [urlError, setUrlError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<ImportResult | null>(null);
+  const [importProgress, setImportProgress] = useState<ImportProgress>({
+    current: 0,
+    total: 0,
+    successCount: 0,
+    failedCount: 0,
+    status: 'idle',
+    errors: [],
+  });
+  const [summary, setSummary] = useState<ImportSummary | null>(null);
 
   const handleUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const url = e.target.value;
@@ -44,66 +50,190 @@ export default function Home() {
     }
   }, []);
 
-  const handleJsonParsed = (data: Record<string, unknown>, name: string) => {
-    setJsonData(data);
-    setSourceName(name);
+  const handleJsonParsed = useCallback((files: ParsedFile[]) => {
+    setParsedFiles(files);
+  }, []);
+
+  const handleProceedToPreview = useCallback(() => {
+    const validFiles = parsedFiles.filter(
+      (f) => f.status !== 'error' && f.records.length > 0
+    );
+    if (validFiles.length === 0) {
+      setError('インポート可能なファイルがありません');
+      return;
+    }
+    if (!urlInfo) {
+      setError('Lark Base URLを入力してください');
+      return;
+    }
+    setError(null);
     setStep('preview');
-  };
+  }, [parsedFiles, urlInfo]);
 
   const handleCancel = () => {
     setStep('upload');
-    setJsonData(null);
-    setSourceName('');
     setError(null);
+    setImportProgress({
+      current: 0,
+      total: 0,
+      successCount: 0,
+      failedCount: 0,
+      status: 'idle',
+      errors: [],
+    });
   };
 
   const handleImport = async () => {
-    if (!jsonData || !urlInfo) {
-      setError('JSONデータとLark Base URLが必要です');
+    if (!urlInfo) {
+      setError('Lark Base URLが必要です');
       return;
     }
 
-    setIsLoading(true);
+    const validFiles = parsedFiles.filter(
+      (f) => f.status !== 'error' && f.records.length > 0
+    );
+    const allRecords = validFiles.flatMap((f) => f.records.map((r) => r.data));
+
+    if (allRecords.length === 0) {
+      setError('インポートするレコードがありません');
+      return;
+    }
+
     setError(null);
+    setImportProgress({
+      current: 0,
+      total: allRecords.length,
+      successCount: 0,
+      failedCount: 0,
+      status: 'importing',
+      errors: [],
+    });
 
-    try {
-      const response = await fetch('/api/import', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          jsonData,
-          appToken: urlInfo.appToken,
-          tableId: urlInfo.tableId,
-        }),
-      });
+    // Update file statuses to processing
+    setParsedFiles((prev) =>
+      prev.map((f) =>
+        f.status !== 'error'
+          ? { ...f, status: 'processing' as const }
+          : f
+      )
+    );
 
-      const data = await response.json();
+    let successCount = 0;
+    let failedCount = 0;
+    let createdFieldsCount = 0;
+    const errors: Array<{ index: number; error: string }> = [];
 
-      if (!response.ok || !data.success) {
-        throw new Error(data.error || 'インポートに失敗しました');
+    // Process records in batches of 500
+    const batchSize = 500;
+    for (let i = 0; i < allRecords.length; i += batchSize) {
+      const batch = allRecords.slice(i, i + batchSize);
+
+      try {
+        const response = await fetch('/api/import', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            records: batch,
+            appToken: urlInfo.appToken,
+            tableId: urlInfo.tableId,
+          }),
+        });
+
+        const data = await response.json();
+
+        if (!response.ok || !data.success) {
+          // Handle batch failure
+          for (let j = 0; j < batch.length; j++) {
+            errors.push({
+              index: i + j,
+              error: data.error || 'インポートに失敗しました',
+            });
+          }
+          failedCount += batch.length;
+        } else {
+          successCount += data.data?.successCount || batch.length;
+          failedCount += data.data?.failedCount || 0;
+          createdFieldsCount += data.data?.createdFieldsCount || 0;
+          if (data.data?.errors) {
+            errors.push(...data.data.errors.map((e: { index: number; error: string }) => ({
+              index: i + e.index,
+              error: e.error,
+            })));
+          }
+        }
+      } catch (err) {
+        // Handle network/unexpected errors
+        for (let j = 0; j < batch.length; j++) {
+          errors.push({
+            index: i + j,
+            error: err instanceof Error ? err.message : 'エラーが発生しました',
+          });
+        }
+        failedCount += batch.length;
       }
 
-      setResult(data.data);
+      // Update progress
+      setImportProgress((prev) => ({
+        ...prev,
+        current: Math.min(i + batchSize, allRecords.length),
+        successCount,
+        failedCount,
+        errors,
+      }));
+    }
+
+    // Update file statuses based on results
+    setParsedFiles((prev) =>
+      prev.map((f) =>
+        f.status === 'processing'
+          ? { ...f, status: failedCount === 0 ? 'success' : 'error' }
+          : f
+      )
+    );
+
+    setImportProgress((prev) => ({
+      ...prev,
+      status: 'completed',
+    }));
+
+    setSummary({
+      totalRecords: allRecords.length,
+      successCount,
+      failedCount,
+      createdFieldsCount,
+    });
+
+    if (failedCount === 0) {
       setStep('success');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'エラーが発生しました');
-    } finally {
-      setIsLoading(false);
     }
   };
 
   const handleReset = () => {
     setStep('upload');
-    setJsonData(null);
-    setSourceName('');
+    setParsedFiles([]);
     setLarkUrl('');
     setUrlInfo(null);
     setUrlError(null);
     setError(null);
-    setResult(null);
+    setImportProgress({
+      current: 0,
+      total: 0,
+      successCount: 0,
+      failedCount: 0,
+      status: 'idle',
+      errors: [],
+    });
+    setSummary(null);
   };
+
+  const validFileCount = parsedFiles.filter(
+    (f) => f.status !== 'error' && f.records.length > 0
+  ).length;
+  const totalRecordCount = parsedFiles
+    .filter((f) => f.status !== 'error')
+    .reduce((sum, f) => sum + f.records.length, 0);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
@@ -203,12 +333,38 @@ export default function Home() {
               {/* Divider */}
               <div className="border-t border-gray-200 pt-6">
                 <h3 className="text-sm font-medium text-gray-700 mb-4">JSONデータ</h3>
-                <JsonUploader onJsonParsed={handleJsonParsed} />
+                <JsonUploader
+                  onJsonParsed={handleJsonParsed}
+                  parsedFiles={parsedFiles}
+                />
               </div>
+
+              {/* Error Display */}
+              {error && (
+                <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+                  <p className="text-red-600 text-sm">{error}</p>
+                </div>
+              )}
+
+              {/* Proceed Button */}
+              {parsedFiles.length > 0 && (
+                <div className="pt-4 border-t border-gray-200">
+                  <button
+                    onClick={handleProceedToPreview}
+                    disabled={validFileCount === 0 || !urlInfo}
+                    className="w-full px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+                  >
+                    プレビューへ進む
+                    <span className="text-sm opacity-80">
+                      ({validFileCount}ファイル / {totalRecordCount}レコード)
+                    </span>
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
-          {step === 'preview' && jsonData && (
+          {step === 'preview' && (
             <div className="space-y-6">
               {/* Import Target Info */}
               {urlInfo && (
@@ -229,16 +385,16 @@ export default function Home() {
               )}
 
               <FieldPreview
-                data={jsonData}
-                fileName={sourceName}
+                files={parsedFiles.filter((f) => f.status !== 'error')}
                 onConfirm={handleImport}
                 onCancel={handleCancel}
-                isLoading={isLoading}
+                isLoading={importProgress.status === 'importing'}
+                progress={importProgress}
               />
             </div>
           )}
 
-          {step === 'success' && result && (
+          {step === 'success' && summary && (
             <div className="text-center py-8">
               <div className="text-6xl mb-4">🎉</div>
               <h2 className="text-2xl font-bold text-gray-800 mb-2">
@@ -252,21 +408,23 @@ export default function Home() {
                 <h3 className="font-medium text-gray-700 mb-3">インポート結果</h3>
                 <dl className="space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <dt className="text-gray-500">テーブルID:</dt>
-                    <dd className="font-mono text-gray-800">{result.tableId}</dd>
+                    <dt className="text-gray-500">ファイル数:</dt>
+                    <dd className="font-mono text-gray-800">{validFileCount}ファイル</dd>
                   </div>
                   <div className="flex justify-between">
-                    <dt className="text-gray-500">レコードID:</dt>
-                    <dd className="font-mono text-gray-800">{result.recordId}</dd>
+                    <dt className="text-gray-500">レコード数:</dt>
+                    <dd className="font-mono text-gray-800">{summary.successCount}レコード</dd>
                   </div>
-                  <div className="flex justify-between">
-                    <dt className="text-gray-500">フィールド数:</dt>
-                    <dd className="font-mono text-gray-800">{result.fieldsCount}</dd>
-                  </div>
-                  {result.createdFieldsCount > 0 && (
+                  {summary.failedCount > 0 && (
                     <div className="flex justify-between">
-                      <dt className="text-gray-500">新規作成:</dt>
-                      <dd className="font-mono text-green-600">{result.createdFieldsCount}フィールド</dd>
+                      <dt className="text-gray-500">失敗:</dt>
+                      <dd className="font-mono text-red-600">{summary.failedCount}レコード</dd>
+                    </div>
+                  )}
+                  {summary.createdFieldsCount > 0 && (
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">新規フィールド:</dt>
+                      <dd className="font-mono text-green-600">{summary.createdFieldsCount}フィールド</dd>
                     </div>
                   )}
                 </dl>

--- a/src/components/FieldPreview.tsx
+++ b/src/components/FieldPreview.tsx
@@ -1,48 +1,53 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { ParsedFile, ParsedRecord } from './JsonUploader';
+
+export interface ImportProgress {
+  current: number;
+  total: number;
+  successCount: number;
+  failedCount: number;
+  status: 'idle' | 'importing' | 'completed' | 'error';
+  errors: Array<{ index: number; error: string }>;
+}
 
 interface FieldPreviewProps {
-  data: Record<string, unknown>;
-  fileName: string;
+  files: ParsedFile[];
   onConfirm: () => void;
   onCancel: () => void;
   isLoading?: boolean;
+  progress?: ImportProgress;
 }
 
 type FieldType = 'string' | 'number' | 'boolean' | 'url' | 'email' | 'longtext' | 'array' | 'object' | 'null';
 
-function inferFieldType(key: string, value: unknown): FieldType {
+function inferFieldType(value: unknown): FieldType {
   if (value === null || value === undefined) return 'null';
   if (Array.isArray(value)) return 'array';
   if (typeof value === 'object') return 'object';
   if (typeof value === 'boolean') return 'boolean';
   if (typeof value === 'number') return 'number';
   if (typeof value === 'string') {
-    // URL detection
     if (/^https?:\/\//.test(value)) return 'url';
-    // Email detection
     if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) return 'email';
-    // Long text detection (over 100 chars or contains newlines)
     if (value.length > 100 || value.includes('\n')) return 'longtext';
     return 'string';
   }
   return 'string';
 }
 
-function formatValue(value: unknown, maxLength: number = 80): string {
+function formatValue(value: unknown, maxLength: number = 50): string {
   if (value === null || value === undefined) return '-';
   if (typeof value === 'object') {
     const str = JSON.stringify(value);
     return str.length > maxLength ? str.slice(0, maxLength) + '...' : str;
   }
   if (typeof value === 'string') {
-    // Replace newlines with visual indicator
-    const formatted = value.replace(/\n/g, ' ↵ ');
+    const formatted = value.replace(/\n/g, ' ');
     return formatted.length > maxLength ? formatted.slice(0, maxLength) + '...' : formatted;
   }
   if (typeof value === 'number') {
-    // Format large numbers with commas
     return value.toLocaleString('ja-JP');
   }
   return String(value);
@@ -50,72 +55,103 @@ function formatValue(value: unknown, maxLength: number = 80): string {
 
 function getTypeColor(type: FieldType): string {
   switch (type) {
-    case 'string':
-      return 'bg-green-100 text-green-800';
-    case 'number':
-      return 'bg-blue-100 text-blue-800';
-    case 'boolean':
-      return 'bg-purple-100 text-purple-800';
-    case 'object':
-      return 'bg-yellow-100 text-yellow-800';
-    case 'array':
-      return 'bg-orange-100 text-orange-800';
-    case 'url':
-      return 'bg-cyan-100 text-cyan-800';
-    case 'email':
-      return 'bg-pink-100 text-pink-800';
-    case 'longtext':
-      return 'bg-indigo-100 text-indigo-800';
-    case 'null':
-      return 'bg-gray-100 text-gray-500';
-    default:
-      return 'bg-gray-100 text-gray-800';
+    case 'string': return 'bg-green-100 text-green-800';
+    case 'number': return 'bg-blue-100 text-blue-800';
+    case 'boolean': return 'bg-purple-100 text-purple-800';
+    case 'object': return 'bg-yellow-100 text-yellow-800';
+    case 'array': return 'bg-orange-100 text-orange-800';
+    case 'url': return 'bg-cyan-100 text-cyan-800';
+    case 'email': return 'bg-pink-100 text-pink-800';
+    case 'longtext': return 'bg-indigo-100 text-indigo-800';
+    case 'null': return 'bg-gray-100 text-gray-500';
+    default: return 'bg-gray-100 text-gray-800';
   }
 }
 
 export default function FieldPreview({
-  data,
-  fileName,
+  files,
   onConfirm,
   onCancel,
   isLoading = false,
+  progress,
 }: FieldPreviewProps) {
-  const fields = useMemo(() => {
-    return Object.entries(data).map(([key, value]) => ({
-      key,
-      value,
-      type: inferFieldType(key, value),
-    }));
-  }, [data]);
+  const [previewLimit] = useState(10);
+
+  // Get all records from all files
+  const allRecords = useMemo(() => {
+    return files.flatMap((file) =>
+      file.records.map((record, index) => ({
+        ...record,
+        fileName: file.fileName,
+        recordIndex: index,
+      }))
+    );
+  }, [files]);
+
+  // Collect all unique field names across all records
+  const fieldNames = useMemo(() => {
+    const names = new Set<string>();
+    allRecords.forEach((record) => {
+      Object.keys(record.data).forEach((key) => names.add(key));
+    });
+    return Array.from(names);
+  }, [allRecords]);
+
+  // Infer types from first non-null value
+  const fieldTypes = useMemo(() => {
+    const types: Record<string, FieldType> = {};
+    fieldNames.forEach((name) => {
+      for (const record of allRecords) {
+        const value = record.data[name];
+        if (value !== null && value !== undefined) {
+          types[name] = inferFieldType(value);
+          break;
+        }
+      }
+      if (!types[name]) {
+        types[name] = 'null';
+      }
+    });
+    return types;
+  }, [fieldNames, allRecords]);
+
+  const totalRecords = allRecords.length;
+  const previewRecords = allRecords.slice(0, previewLimit);
+  const hasMore = totalRecords > previewLimit;
+
+  const isImporting = progress?.status === 'importing';
+  const isCompleted = progress?.status === 'completed';
 
   return (
     <div className="w-full">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h2 className="text-xl font-bold text-gray-800">フィールドプレビュー</h2>
+          <h2 className="text-xl font-bold text-gray-800">レコードプレビュー</h2>
           <p className="text-sm text-gray-500">
-            {fileName} - {fields.length} フィールド
+            {files.length}ファイル / {totalRecords}レコード / {fieldNames.length}フィールド
           </p>
         </div>
         <div className="flex gap-3">
           <button
             onClick={onCancel}
-            disabled={isLoading}
+            disabled={isLoading || isImporting}
             className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
           >
             キャンセル
           </button>
           <button
             onClick={onConfirm}
-            disabled={isLoading}
+            disabled={isLoading || isImporting || isCompleted}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 flex items-center gap-2"
           >
-            {isLoading ? (
+            {isImporting ? (
               <>
                 <span className="animate-spin">⏳</span>
                 インポート中...
               </>
+            ) : isCompleted ? (
+              <>完了</>
             ) : (
               <>
                 <span>🚀</span>
@@ -126,49 +162,97 @@ export default function FieldPreview({
         </div>
       </div>
 
-      {/* Fields Table */}
+      {/* Progress Bar */}
+      {progress && progress.status !== 'idle' && (
+        <div className="mb-6">
+          <div className="flex justify-between text-sm text-gray-600 mb-2">
+            <span>進捗: {progress.current} / {progress.total}</span>
+            <span>
+              成功: {progress.successCount} / 失敗: {progress.failedCount}
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-3">
+            <div
+              className={`h-3 rounded-full transition-all duration-300 ${
+                progress.failedCount > 0 ? 'bg-yellow-500' : 'bg-blue-600'
+              }`}
+              style={{ width: `${(progress.current / progress.total) * 100}%` }}
+            />
+          </div>
+          {progress.status === 'completed' && (
+            <div className={`mt-2 text-sm ${progress.failedCount > 0 ? 'text-yellow-600' : 'text-green-600'}`}>
+              {progress.failedCount > 0
+                ? `インポート完了（${progress.failedCount}件の失敗）`
+                : 'すべてのレコードが正常にインポートされました'
+              }
+            </div>
+          )}
+          {progress.errors.length > 0 && (
+            <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg max-h-32 overflow-y-auto">
+              <p className="text-sm font-medium text-red-800 mb-2">エラー詳細:</p>
+              {progress.errors.slice(0, 5).map((err, i) => (
+                <p key={i} className="text-xs text-red-600">
+                  レコード {err.index + 1}: {err.error}
+                </p>
+              ))}
+              {progress.errors.length > 5 && (
+                <p className="text-xs text-red-500 mt-1">
+                  ...他 {progress.errors.length - 5} 件のエラー
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Field Types */}
+      <div className="mb-4">
+        <h3 className="text-sm font-medium text-gray-700 mb-2">フィールド一覧</h3>
+        <div className="flex flex-wrap gap-2">
+          {fieldNames.map((name) => (
+            <div key={name} className="flex items-center gap-1">
+              <code className="text-xs bg-gray-100 px-2 py-1 rounded">{name}</code>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${getTypeColor(fieldTypes[name])}`}>
+                {fieldTypes[name]}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Records Table */}
       <div className="border border-gray-200 rounded-xl overflow-hidden">
-        <div className="max-h-[500px] overflow-y-auto">
-          <table className="w-full">
+        <div className="max-h-[400px] overflow-auto">
+          <table className="w-full text-sm">
             <thead className="bg-gray-50 sticky top-0">
               <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-600 w-8">
-                  #
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-600 w-1/4">
-                  フィールド名
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-600 w-24">
-                  型
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">
-                  値（プレビュー）
-                </th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-600 w-12">#</th>
+                {fieldNames.slice(0, 5).map((name) => (
+                  <th key={name} className="px-3 py-2 text-left text-xs font-medium text-gray-600 max-w-[200px]">
+                    {name}
+                  </th>
+                ))}
+                {fieldNames.length > 5 && (
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-400">
+                    +{fieldNames.length - 5}
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {fields.map((field, index) => (
-                <tr key={field.key} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 text-sm text-gray-400">{index + 1}</td>
-                  <td className="px-4 py-3">
-                    <code className="text-sm bg-gray-100 px-2 py-1 rounded">
-                      {field.key}
-                    </code>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`text-xs px-2 py-1 rounded-full ${getTypeColor(
-                        field.type
-                      )}`}
-                    >
-                      {field.type}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="text-sm text-gray-600 font-mono">
-                      {formatValue(field.value)}
-                    </span>
-                  </td>
+              {previewRecords.map((record, index) => (
+                <tr key={`${record.fileName}-${record.recordIndex}`} className="hover:bg-gray-50">
+                  <td className="px-3 py-2 text-xs text-gray-400">{index + 1}</td>
+                  {fieldNames.slice(0, 5).map((name) => (
+                    <td key={name} className="px-3 py-2 max-w-[200px]">
+                      <span className="text-xs text-gray-600 font-mono truncate block">
+                        {formatValue(record.data[name])}
+                      </span>
+                    </td>
+                  ))}
+                  {fieldNames.length > 5 && (
+                    <td className="px-3 py-2 text-xs text-gray-400">...</td>
+                  )}
                 </tr>
               ))}
             </tbody>
@@ -176,13 +260,22 @@ export default function FieldPreview({
         </div>
       </div>
 
+      {hasMore && (
+        <p className="mt-2 text-xs text-gray-500 text-center">
+          他 {totalRecords - previewLimit} 件のレコードがあります
+        </p>
+      )}
+
       {/* Summary */}
       <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
         <p className="text-sm text-blue-800">
-          <strong>インポート内容:</strong> 1レコード / {fields.length}フィールド
+          <strong>インポート内容:</strong> {totalRecords}レコード / {fieldNames.length}フィールド
         </p>
         <p className="text-xs text-blue-600 mt-1">
-          新しいテーブルが作成され、JSONデータが1レコードとして追加されます
+          {totalRecords > 500
+            ? `500レコードごとに分割してバッチ処理されます（計 ${Math.ceil(totalRecords / 500)} バッチ）`
+            : '既存のテーブルにレコードが追加されます'
+          }
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- JSON配列形式のデータから複数レコードを一括でインポートできるように機能追加
- `[{...}, {...}, {...}]` 形式のJSONをサポート
- Lark API の batch_create を使用した効率的なバッチ処理（最大500レコード/リクエスト）
- インポート進捗をプログレスバーで視覚的に表示
- 部分的な失敗のハンドリングとエラー詳細の表示

## Changes
- `JsonUploader.tsx`: JSON配列形式の入力を許可
- `FieldPreview.tsx`: 複数レコードのテーブル形式プレビュー、進捗バー追加
- `lib/lark.ts`: `batchCreateRecords()` 関数追加
- `api/import/route.ts`: バッチインポートAPIに更新
- `page.tsx`: 新データ構造と進捗表示に対応

## Test plan
- [ ] 単一オブジェクトJSONのインポートが動作する
- [ ] JSON配列のインポートが動作する
- [ ] 複数ファイルのインポートが動作する
- [ ] 500件以上のレコードがバッチ分割される
- [ ] 進捗バーが正しく表示される
- [ ] 部分的な失敗時にエラーが表示される

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)